### PR TITLE
Made search function non case-sensitive

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,9 +1,10 @@
 annotation.processing.enabled=true
 annotation.processing.enabled.in.editor=false
-annotation.processing.processor.options=
 annotation.processing.processors.list=
 annotation.processing.run.all.processors=true
 annotation.processing.source.output=${build.generated.sources.dir}/ap-source-output
+application.title=SimpleJavaTextEditor
+application.vendor=Ossi
 build.classes.dir=${build.dir}/classes
 build.classes.excludes=**/*.java,**/*.form
 # This directory is removed when the project is cleaned:
@@ -26,6 +27,7 @@ dist.archive.excludes=
 dist.dir=dist
 dist.jar=${dist.dir}/SimpleJavaTextEditor.jar
 dist.javadoc.dir=${dist.dir}/javadoc
+endorsed.classpath=
 excludes=
 includes=**
 jar.compress=false
@@ -33,10 +35,11 @@ javac.classpath=
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
+javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.8
-javac.target=1.8
+javac.source=1.7
+javac.target=1.7
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,10 +1,9 @@
 annotation.processing.enabled=true
 annotation.processing.enabled.in.editor=false
+annotation.processing.processor.options=
 annotation.processing.processors.list=
 annotation.processing.run.all.processors=true
 annotation.processing.source.output=${build.generated.sources.dir}/ap-source-output
-application.title=SimpleJavaTextEditor
-application.vendor=Ossi
 build.classes.dir=${build.dir}/classes
 build.classes.excludes=**/*.java,**/*.form
 # This directory is removed when the project is cleaned:
@@ -27,7 +26,6 @@ dist.archive.excludes=
 dist.dir=dist
 dist.jar=${dist.dir}/SimpleJavaTextEditor.jar
 dist.javadoc.dir=${dist.dir}/javadoc
-endorsed.classpath=
 excludes=
 includes=**
 jar.compress=false
@@ -35,11 +33,10 @@ javac.classpath=
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.7
-javac.target=1.7
+javac.source=1.8
+javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}

--- a/src/simplejavatexteditor/Find.java
+++ b/src/simplejavatexteditor/Find.java
@@ -28,12 +28,10 @@ public class Find extends JFrame implements ActionListener {
 
 	private static final long serialVersionUID = 1L;
 	int startIndex=0;
-        int select_start=-1;
     JLabel lab1, lab2;
     JTextField textF, textR;
     JButton findBtn, findNext, replace, replaceAll, cancel;  
     private JTextArea txt;
-    
     
     public Find(JTextArea text) { 
     	this.txt = text;
@@ -102,7 +100,7 @@ public class Find extends JFrame implements ActionListener {
     }
     
     public void find() {
-        select_start = txt.getText().toLowerCase().indexOf(textF.getText().toLowerCase());        
+        int select_start = txt.getText().toLowerCase().indexOf(textF.getText().toLowerCase());        
         if(select_start == -1)
         {
             startIndex = 0;
@@ -156,7 +154,6 @@ public class Find extends JFrame implements ActionListener {
         try
         {
             find();
-            if (select_start != -1)
             txt.replaceSelection(textR.getText());
         }
         catch(NullPointerException e)

--- a/src/simplejavatexteditor/Find.java
+++ b/src/simplejavatexteditor/Find.java
@@ -100,14 +100,14 @@ public class Find extends JFrame implements ActionListener {
     }
     
     public void find() {
-        int select_start = txt.getText().indexOf(textF.getText());        
+        int select_start = txt.getText().toLowerCase().indexOf(textF.getText().toLowerCase());        
         if(select_start == -1)
         {
             startIndex = 0;
             JOptionPane.showMessageDialog(null, "Could not find \"" + textF.getText() + "\"!");
             return;
         }
-        if(select_start == txt.getText().lastIndexOf(textF.getText()))
+        if(select_start == txt.getText().toLowerCase().lastIndexOf(textF.getText().toLowerCase()))
         {
             startIndex = 0;
         }        
@@ -136,12 +136,12 @@ public class Find extends JFrame implements ActionListener {
         }
         try
         {
-            int select_start = txt.getText().indexOf(selection, startIndex);
+            int select_start = txt.getText().toLowerCase().indexOf(selection.toLowerCase(), startIndex);
             int select_end = select_start+selection.length();
             txt.select(select_start, select_end);
             startIndex = select_end+1;
         
-            if(select_start == txt.getText().lastIndexOf(selection))
+            if(select_start == txt.getText().toLowerCase().lastIndexOf(selection.toLowerCase()))
             {
                 startIndex = 0;
             }
@@ -163,9 +163,9 @@ public class Find extends JFrame implements ActionListener {
     }
     
     public void replaceAll() {      
-        txt.setText(txt.getText().replaceAll(textF.getText(), textR.getText()));
+        txt.setText(txt.getText().toLowerCase().replaceAll(textF.getText().toLowerCase(), textR.getText()));
     }
- 
+
     public void actionPerformed(ActionEvent e) {
         if(e.getSource() == findBtn)
         {

--- a/src/simplejavatexteditor/Find.java
+++ b/src/simplejavatexteditor/Find.java
@@ -28,10 +28,12 @@ public class Find extends JFrame implements ActionListener {
 
 	private static final long serialVersionUID = 1L;
 	int startIndex=0;
+        int select_start=-1;
     JLabel lab1, lab2;
     JTextField textF, textR;
     JButton findBtn, findNext, replace, replaceAll, cancel;  
     private JTextArea txt;
+    
     
     public Find(JTextArea text) { 
     	this.txt = text;
@@ -100,7 +102,7 @@ public class Find extends JFrame implements ActionListener {
     }
     
     public void find() {
-        int select_start = txt.getText().toLowerCase().indexOf(textF.getText().toLowerCase());        
+        select_start = txt.getText().toLowerCase().indexOf(textF.getText().toLowerCase());        
         if(select_start == -1)
         {
             startIndex = 0;
@@ -154,6 +156,7 @@ public class Find extends JFrame implements ActionListener {
         try
         {
             find();
+            if (select_start != -1)
             txt.replaceSelection(textR.getText());
         }
         catch(NullPointerException e)


### PR DESCRIPTION
Search function (find, find next, replace, replace all) now doesn't
differentiate between lower-cases and upper-cases. Previously couldn't
find the word "Example" when "example" was typed into the search field.
