### PR TITLE
Set Find class  relative to jTextarea and 2 bug fixed (clases Find and About)

### DIFF
--- a/src/simplejavatexteditor/About.java
+++ b/src/simplejavatexteditor/About.java
@@ -14,12 +14,22 @@
  * @modifiedby  Achintha Gunasekara
  * @modweb      http://www.achinthagunasekara.com
  * @modemail    contact@achinthagunasekara.com
+ * 
+ * @Modifiedby SidaDan
+ * @modemail Fschultz@sinf.de
+ * Bug fixed. If JTextArea txt not empty and the user will
+ * shutdown the Simple Java NotePad, then the Simple Java NotePad
+ * is only hidden (still running). So I added a WindowListener
+ * an call method dispose() for this frame.
+ * Tested with java 8.
  */
 
 package simplejavatexteditor;
 
 import javax.swing.*;
 import java.awt.FlowLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 public class About {
 
@@ -32,6 +42,15 @@ public class About {
         panel = new JPanel(new FlowLayout());
         panel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
         frame = new JFrame();
+        
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                frame.dispose();
+            }
+        });
+
+        
         frame.setVisible(true);
         frame.setSize(500,300);
         frame.setLocationRelativeTo(ui);

--- a/src/simplejavatexteditor/Find.java
+++ b/src/simplejavatexteditor/Find.java
@@ -14,6 +14,15 @@
  * @modifiedby  Achintha Gunasekara
  * @modweb      http://www.achinthagunasekara.com
  * @modemail    contact@achinthagunasekara.com
+ * 
+ * @Modifiedby SidaDan
+ * @modemail Fschultz@sinf.de
+ * Center this JFrame to the JTextArea
+ * Bug fixed. If JTextArea txt not empty and the user will
+ * shutdown the Simple Java NotePad, then the Simple Java NotePad
+ * is only hidden (still running). We need DISPOSE_ON_CLOSE for
+ * this JFrame.
+ * Tested with java 8.
  */
 
 package simplejavatexteditor;
@@ -94,11 +103,10 @@ public class Find extends JFrame implements ActionListener {
         // Set size window
         setSize(width,height);
 
-        // Set window position
-        Point center = GraphicsEnvironment.getLocalGraphicsEnvironment().getCenterPoint();
-        setLocation(center.x-width/2, center.y-height/2);
+        // center the frame on the frame
+        setLocationRelativeTo(txt);
         setVisible(true);
-        setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     }
 
     public void find() {


### PR DESCRIPTION
Hi again :)
Here my changes.
I Centered the "find" frame on the jTextarea.
Also I fixed 2 bugs. If some text was written and the editor shutdown
then the editor is only hidden and still running. 

Regards