### PR TITLE
#Bug, No check on open file option to save changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # Mac OS System
 .DS_Store*
 ._*
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,3 @@
 /build/
 /dist/
 *.class
-
-# Mac OS System
-.DS_Store*
-._*
-/bin/

--- a/src/simplejavatexteditor/UI.java
+++ b/src/simplejavatexteditor/UI.java
@@ -472,7 +472,7 @@ public class UI extends JFrame implements ActionListener {
         else if (e.getSource() == newFile || e.getSource() == newButton) {
             if (edit) {
                 Object[] options = {"Save", "No Save", "Return"};
-                int n = JOptionPane.showOptionDialog(this, "Do you want to save the file at first ?", "Question",
+                int n = JOptionPane.showOptionDialog(this, "Do you want to save changes ?", "Question",
                         JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[2]);
                 if (n == 0) {// save
                     saveFile();
@@ -487,30 +487,23 @@ public class UI extends JFrame implements ActionListener {
 
         } // If the source was the "open" option
         else if (e.getSource() == openFile || e.getSource() == openButton) {
-            JFileChooser open = new JFileChooser(); // open up a file chooser (a dialog for the user to  browse files to open)
-            int option = open.showOpenDialog(this); // get the option that the user selected (approve or cancel)
-
-            /*
-             * NOTE: because we are OPENing a file, we call showOpenDialog~ if
-             * the user clicked OK, we have "APPROVE_OPTION" so we want to open
-             * the file
-             */
-            if (option == JFileChooser.APPROVE_OPTION) {
-                FEdit.clear(textArea); // clear the TextArea before applying the file contents
-                try {
-                    File openFile = open.getSelectedFile();
-                    setTitle(openFile.getName() + " | " + SimpleJavaTextEditor.NAME);
-                    Scanner scan = new Scanner(new FileReader(openFile.getPath()));
-                    while (scan.hasNext()) {
-                        textArea.append(scan.nextLine() + "\n");
-                    }
-
-                    enableAutoComplete(openFile);
-                } catch (Exception ex) { // catch any exceptions, and...
-                    // ...write to the debug console
-                    System.err.println(ex.getMessage());
-                }
-            }
+        	
+        	  if (edit) {
+                  Object[] options = {"Save", "No Save", "Return"};
+                  int n = JOptionPane.showOptionDialog(this, "Do you want to save changes ?", "Question",
+                          JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[2]);
+                  if (n == 0) {// save
+                      saveFile();
+                      edit = false;
+                  } else if (n == 1) {
+                      edit = false;
+                     openFile();
+                  }  
+        		  
+        	  }
+        	 else{
+           openFile();
+        }
         } // If the source of the event was the "save" option
         else if (e.getSource() == saveFile || e.getSource() == saveButton) {
             saveFile();
@@ -595,6 +588,32 @@ public class UI extends JFrame implements ActionListener {
                 System.err.println(ex.getMessage());
             }
         }
+    }
+    private void openFile(){
+    	 JFileChooser open = new JFileChooser(); // open up a file chooser (a dialog for the user to  browse files to open)
+         int option = open.showOpenDialog(this); // get the option that the user selected (approve or cancel)
+
+         /*
+          * NOTE: because we are OPENing a file, we call showOpenDialog~ if
+          * the user clicked OK, we have "APPROVE_OPTION" so we want to open
+          * the file
+          */
+         if (option == JFileChooser.APPROVE_OPTION) {
+             FEdit.clear(textArea); // clear the TextArea before applying the file contents
+             try {
+                 File openFile = open.getSelectedFile();
+                 setTitle(openFile.getName() + " | " + SimpleJavaTextEditor.NAME);
+                 Scanner scan = new Scanner(new FileReader(openFile.getPath()));
+                 while (scan.hasNext()) {
+                     textArea.append(scan.nextLine() + "\n");
+                 }
+
+                 enableAutoComplete(openFile);
+             } catch (Exception ex) { // catch any exceptions, and...
+                 // ...write to the debug console
+                 System.err.println(ex.getMessage());
+             }
+         }
     }
 
 }

--- a/src/simplejavatexteditor/UI.java
+++ b/src/simplejavatexteditor/UI.java
@@ -481,7 +481,7 @@ public class UI extends JFrame implements ActionListener {
         else if (e.getSource() == newFile || e.getSource() == newButton) {
             if (edit) {
                 Object[] options = {"Save", "No Save", "Return"};
-                int n = JOptionPane.showOptionDialog(this, "Do you want to save changes ?", "Question",
+                 int n = JOptionPane.showOptionDialog(this, "Do you want to save the changes ?", "Question",
                         JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[2]);
                 if (n == 0) {// save
                     saveFile();
@@ -499,7 +499,7 @@ public class UI extends JFrame implements ActionListener {
         	
         	  if (edit) {
                   Object[] options = {"Save", "No Save", "Return"};
-                  int n = JOptionPane.showOptionDialog(this, "Do you want to save changes ?", "Question",
+                  int n = JOptionPane.showOptionDialog(this, "Do you want to save changes?", "Question",
                           JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[2]);
                   if (n == 0) {// save
                       saveFile();


### PR DESCRIPTION
Fixed.
Hi,
First of all, I really appreciate your work towards open source community.
I really wants to contribute in this project So, I started to test Text-editor and found some bug that there is no check on open file option to save changes if there is text in notepad.
can you please merge my pull request or  add fallowing lines of code in your UI.java  class for open file option.
// If the source was the "open" option